### PR TITLE
Fixed tags filter links at the top

### DIFF
--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -27,11 +27,11 @@ pagination:
   {% if page.url contains slug %}
 
 
-  <a href="/tag/{{ tag }}" class="tag-filter-selected">{{ tag }}</a>
+  <a href="{{ '/tag/' | append: tag | relative_url | downcase }}" class="tag-filter-selected">{{ tag }}</a>
 
   {% else %}
 
-  <a href="/tag/{{ tag }}" class="tag-filter">{{ tag }}</a>
+  <a href="{{ '/tag/' | append: tag | relative_url | downcase }}" class="tag-filter">{{ tag }}</a>
 
   {% endif %}
 


### PR DESCRIPTION
The tags menu under Our Latest Pulls had incorrect paths for tags. This update will fix it. 